### PR TITLE
New Scope tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@latitude-data/promptl",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@latitude-data/promptl",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@latitude-data/promptl",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "author": "Latitude Data",
   "license": "MIT",
   "description": "Compiler for PromptL, the prompt language",

--- a/src/compiler/base/nodes/tag.ts
+++ b/src/compiler/base/nodes/tag.ts
@@ -3,6 +3,7 @@ import {
   isContentTag,
   isMessageTag,
   isRefTag,
+  isScopeTag,
 } from '$promptl/compiler/utils'
 import errors from '$promptl/error/errors'
 import {
@@ -11,6 +12,7 @@ import {
   ElementTag,
   MessageTag,
   ReferenceTag,
+  ScopeTag,
 } from '$promptl/parser/interfaces'
 
 import { CompileNodeContext } from '../types'
@@ -18,6 +20,7 @@ import { compile as resolveContent } from './tags/content'
 import { compile as resolveMessage } from './tags/message'
 import { compile as resolveRef } from './tags/ref'
 import { compile as resolveChainStep } from './tags/step'
+import { compile as resolveScope } from './tags/scope'
 
 async function resolveTagAttributes({
   node: tagNode,
@@ -92,6 +95,11 @@ export async function compile(props: CompileNodeContext<ElementTag>) {
 
   if (isRefTag(node)) {
     await resolveRef(props as CompileNodeContext<ReferenceTag>, attributes)
+    return
+  }
+
+  if (isScopeTag(node)) {
+    await resolveScope(props as CompileNodeContext<ScopeTag>, attributes)
     return
   }
 

--- a/src/compiler/base/nodes/tags/scope.test.ts
+++ b/src/compiler/base/nodes/tags/scope.test.ts
@@ -1,0 +1,132 @@
+import { Adapters, Chain, render } from '$promptl/compiler'
+import { complete } from '$promptl/compiler/test/helpers'
+import { removeCommonIndent } from '$promptl/compiler/utils'
+import CompileError from '$promptl/error/error'
+import { getExpectedError } from '$promptl/test/helpers'
+import {
+  MessageRole,
+  SystemMessage,
+  UserMessage,
+} from '$promptl/types'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('scope tags', async () => {
+  it('returns contents as usual', async () => {
+    const prompt = removeCommonIndent(`
+      <user>
+        <scope>
+          <content-text>This is a text content!</content-text>
+        </scope>
+      </user>
+    `)
+
+    const result = await render({ prompt, adapter: Adapters.default })
+
+    expect(result.messages.length).toBe(1)
+    expect(result.messages[0]!.role).toBe(MessageRole.user)
+    const message = result.messages[0]! as UserMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: 'This is a text content!',
+      },
+    ])
+  })
+
+  it('contains its own scope', async () => {
+    const prompt = removeCommonIndent(`
+      {{ foo = 'foo' }}
+      {{ bar = 'bar' }}
+
+      <scope baz={{ bar }}>
+        {{ baz = 'baz' }}
+        {{ foo = 'new foo' }}
+      </scope>
+
+      <content-text>{{ foo }}</content-text>
+      <content-text>{{ bar }}</content-text>
+    `)
+
+    const result = await render({ prompt, adapter: Adapters.default })
+    
+    expect(result.messages.length).toBe(1)
+    const message = result.messages[0]! as SystemMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: 'foo',
+      },
+      {
+        type: 'text',
+        text: 'bar',
+      },
+    ])
+  })
+
+  it('does not automatically inherit variables or parameters from parents', async () => {
+    const prompt = removeCommonIndent(`
+      {{ foo = 'bar' }}
+      <scope>
+        {{ foo }}
+      </scope>
+    `)
+
+    const action = () => render({
+      prompt,
+      parameters: { foo: 'baz' },
+      adapter: Adapters.default
+    })
+
+    const error = await getExpectedError(action, CompileError)
+    expect(error.code).toBe('variable-not-declared')
+  })
+
+  it('can inherit parameters from parents if explicitly passed', async () => {
+    const prompt = removeCommonIndent(`
+      <scope foo={{ foo }}>
+        {{ foo }}
+      </scope>
+    `)
+
+    const result = await render({
+      prompt,
+      parameters: { foo: 'bar' },
+      adapter: Adapters.default
+    })
+
+    expect(result.messages.length).toBe(1)
+    const message = result.messages[0]! as SystemMessage
+    expect(message.content).toEqual([
+      {
+        type: 'text',
+        text: 'bar',
+      },
+    ])
+  })
+
+  it('node state from scope is correctly cached during steps', async () => {
+    const func = vi.fn()
+
+    const prompt = removeCommonIndent(`
+      <scope func={{ func }}>
+        <step>
+          {{ func() }}
+        </step>
+        {{ for i in [1, 2] }}
+          <step>
+            {{ func() }}
+          </step>
+        {{ endfor }}
+      </scope>
+    `)
+
+    const chain = new Chain({
+      prompt,
+      parameters: { func },
+    })
+
+    await complete({ chain })
+
+    expect(func).toHaveBeenCalledTimes(3)
+  })
+})

--- a/src/compiler/base/nodes/tags/scope.ts
+++ b/src/compiler/base/nodes/tags/scope.ts
@@ -1,0 +1,24 @@
+import Scope from '$promptl/compiler/scope'
+import { ScopeTag } from '$promptl/parser/interfaces'
+
+import { CompileNodeContext } from '../../types'
+
+export async function compile(
+  props: CompileNodeContext<ScopeTag>,
+  attributes: Record<string, unknown>,
+) {
+  const {
+    node,
+    resolveBaseNode,
+  } = props
+
+  const childScope = new Scope(attributes)
+
+  for await (const childNode of node.children) {
+    await resolveBaseNode({
+      ...props,
+      node: childNode,
+      scope: childScope,
+    })
+  }
+}

--- a/src/compiler/utils.ts
+++ b/src/compiler/utils.ts
@@ -5,6 +5,7 @@ import {
   ElementTag,
   MessageTag,
   ReferenceTag,
+  ScopeTag,
 } from '$promptl/parser/interfaces'
 import { ContentTypeTagName, MessageRole } from '$promptl/types'
 import { Scalar, Node as YAMLItem, YAMLMap, YAMLSeq } from 'yaml'
@@ -55,6 +56,10 @@ export function isRefTag(tag: ElementTag): tag is ReferenceTag {
 
 export function isChainStepTag(tag: ElementTag): tag is ChainStepTag {
   return tag.name === TAG_NAMES.step
+}
+
+export function isScopeTag(tag: ElementTag): tag is ScopeTag {
+  return tag.name === TAG_NAMES.scope
 }
 
 export function tagAttributeIsLiteral(tag: ElementTag, name: string): boolean {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ export enum TAG_NAMES {
   image = ContentTypeTagName.image,
   toolCall = ContentTypeTagName.toolCall,
   prompt = 'prompt',
+  scope = 'scope',
   step = 'step',
 }
 

--- a/src/parser/interfaces.ts
+++ b/src/parser/interfaces.ts
@@ -46,11 +46,14 @@ export type ContentTag =
   | IElementTag<typeof TAG_NAMES.content>
 
 export type ReferenceTag = IElementTag<typeof TAG_NAMES.prompt>
+export type ScopeTag = IElementTag<typeof TAG_NAMES.scope>
 export type ChainStepTag = IElementTag<typeof TAG_NAMES.step>
 export type ElementTag =
   | ContentTag
   | MessageTag
   | ReferenceTag
+  | ScopeTag
+  | ChainStepTag
   | IElementTag<string>
 
 export type MustacheTag = BaseNode & {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,7 @@ export type Conversation = {
 
 export type ConversationMetadata = {
   hash: string
+  resolvedPrompt: string
   config: Config
   errors: CompileError[]
   parameters: Set<string> // Variables used in the prompt that have not been defined in runtime


### PR DESCRIPTION
New `<scope>` tag!

A new `<scope>` tag has been added to the library! This tag's purpose is for internal use, so it won't be explained in the docs, although it will work if used in a regular query!

How it works: The `scope` defines a content where the variables scope is completely independent from outside. The tag can receive any number of attributes, which define the starter scope of the variables of the content.

Example:
```
{{ foo = 2 }}
{{ bar = 3 }}

<scope bar={{ bar }}>
  {{ bar = 10 }}
  {{ qux = 15 }}

  {{ foo }}  /* error: not defined */
  {{ bar }}  /* 10 */
  {{ qux }}  /* 15 */
</scope>

{{ foo }}  /* 2 */
{{ bar }}  /* 3 */
{{ qux }}  /* error: not defined */
```

Now, the `scan` method will also return a `resolvedPrompt`. When the scanned prompt contains `<prompt path="...">` tags, it will replace them with the new `<scope>` tags and the contents of the reference. This will effectively "cache" the references so that it can be used with both the `render` method or `Chain` class without having to re-evaluate the references! Of course, this step can be skipped and still evaluate the references directly in these other methods!

**Example:**
Original prompt (this can still work with `render` and `Chain` if a `referenceFn` is provided):
```
<system>
  <prompt path="./system_description" assistant_name={{ name }} />
</system>
```

Resolved prompt:
```
<system>
  <scope assistant_name={{ name }}>
    You're {{ assistant_name }}, an AI assistant yada yada yada...
  </scope>
</system>
```