### PR TITLE
Enforce presence of `<tool>` name attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "promptl-ai",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": "Latitude Data",
   "license": "MIT",
   "description": "Compiler for PromptL, the prompt language",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -60,6 +60,7 @@ export default [
       'yaml',
       'crypto',
       'zod',
+      'fast-sha256',
     ],
   },
   {

--- a/src/compiler/base/nodes/tags/message.test.ts
+++ b/src/compiler/base/nodes/tags/message.test.ts
@@ -268,4 +268,30 @@ describe('message contents', async () => {
       },
     ])
   })
+    it('parse <tool> tag', async () => {
+    const prompt = `
+      <tool name="tool1" id="1">Tool 1</tool>
+      <tool name="tool2" id="2">Tool 2</tool>
+    `
+    const result = await render({
+      prompt: removeCommonIndent(prompt),
+      parameters: {},
+      adapter: Adapters.default,
+    })
+    expect(result.messages.length).toBe(2)
+    expect(result.messages).toEqual([
+      {
+        toolId: '1',
+        toolName: 'tool1',
+        role: 'tool',
+        content: [{ type: 'text', text: 'Tool 1' }],
+      },
+      {
+        toolId: '2',
+        toolName: 'tool2',
+        role: 'tool',
+        content: [{ type: 'text', text: 'Tool 2' }],
+      },
+    ])
+  })
 })

--- a/src/compiler/base/nodes/tags/message.ts
+++ b/src/compiler/base/nodes/tags/message.ts
@@ -103,8 +103,14 @@ function buildMessage<R extends MessageRole>(
       baseNodeError(errors.toolMessageWithoutId, node)
     }
 
+    if (attributes.name === undefined) {
+      baseNodeError(errors.toolMessageWithoutName, node)
+    }
+
     message.toolId = String(attributes.id)
+    message.toolName = String(attributes.name)
     delete message['id']
+    delete message['name']
   }
 
   return message

--- a/src/compiler/scan.test.ts
+++ b/src/compiler/scan.test.ts
@@ -725,4 +725,30 @@ describe('syntax errors', async () => {
 
     expect(metadata.errors.length).toBe(0)
   })
+
+  it('throw error if tool does not have id', async () => {
+    const prompt = removeCommonIndent(`
+      <tool>Tool 1</tool>
+    `)
+
+    const metadata = await scan({ prompt })
+
+    expect(metadata.errors).toEqual([
+      new CompileError('Tool messages must have an id attribute'),
+    ])
+  })
+
+  it('throw error if tool does not have name', async () => {
+    const prompt = removeCommonIndent(`
+      <tool id="1">Tool 1</tool>
+    `)
+
+    const metadata = await scan({ prompt })
+
+    expect(metadata.errors).toEqual([
+      new CompileError(
+        'Tool messages must have a name attribute equal to the tool name used in tool-call',
+      ),
+    ])
+  })
 })

--- a/src/compiler/scan.ts
+++ b/src/compiler/scan.ts
@@ -484,6 +484,11 @@ export class Scan {
           return
         }
 
+        if (role === MessageRole.tool && !attributes.has('name')) {
+          this.baseNodeError(errors.toolMessageWithoutName, node)
+          return
+        }
+
         if (this.accumulatedToolCalls.length > 0) {
           this.accumulatedToolCalls.forEach((toolCallNode) => {
             this.baseNodeError(errors.invalidToolCallPlacement, toolCallNode)

--- a/src/error/errors.ts
+++ b/src/error/errors.ts
@@ -169,6 +169,11 @@ export default {
     code: 'tool-message-without-id',
     message: 'Tool messages must have an id attribute',
   },
+  toolMessageWithoutName: {
+    code: 'tool-message-without-name',
+    message:
+      'Tool messages must have a name attribute equal to the tool name used in tool-call',
+  },
   toolCallWithoutName: {
     code: 'tool-call-without-name',
     message: 'Tool calls must have a name attribute',

--- a/src/providers/anthropic/adapter.test.ts
+++ b/src/providers/anthropic/adapter.test.ts
@@ -91,7 +91,7 @@ describe('Anthropic adapter', async () => {
 
   it('adapts tool messages', async () => {
     const prompt = removeCommonIndent(`
-      <tool id="1234">
+      <tool id="1234" name="temperature">
         17ºC
       </tool>
     `)
@@ -99,6 +99,7 @@ describe('Anthropic adapter', async () => {
     const { messages } = await render({ prompt, adapter: Adapters.anthropic })
     expect(messages).toEqual([
       {
+        toolName: 'temperature',
         role: MessageRole.user,
         content: [
           {

--- a/src/providers/openai/adapter.test.ts
+++ b/src/providers/openai/adapter.test.ts
@@ -92,7 +92,7 @@ describe('OpenAI adapter', async () => {
 
   it('adapts tool messages', async () => {
     const prompt = removeCommonIndent(`
-      <tool id="1234">
+      <tool id="1234" name="temperature">
         17ºC
       </tool>
     `)
@@ -102,6 +102,7 @@ describe('OpenAI adapter', async () => {
       {
         role: MessageRole.tool,
         tool_call_id: '1234',
+        toolName: 'temperature',
         content: [{ type: 'text', text: '17ºC' }],
       },
     ])

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -86,6 +86,7 @@ export type AssistantMessage = IMessage & {
 
 export type ToolMessage = IMessage & {
   role: MessageRole.tool
+  toolName: string
   toolId: string
 }
 


### PR DESCRIPTION
# What?
To allow consistency with what a tool request has (id and name) we want to enforce the presence of "name" attribute on tool responses tag