### PR TITLE
Custom PromptLFile type

### DIFF
--- a/src/compiler/base/nodes/mustache.ts
+++ b/src/compiler/base/nodes/mustache.ts
@@ -1,4 +1,10 @@
 import { MustacheTag } from '$promptl/parser/interfaces'
+import {
+  ContentType,
+  isPromptLFile,
+  MessageContent,
+  PromptLFile,
+} from '$promptl/types'
 
 import { CompileNodeContext } from '../types'
 
@@ -6,11 +12,30 @@ export async function compile({
   node,
   scope,
   addStrayText,
+  groupStrayText,
+  isInsideContentTag,
+  addContent,
   resolveExpression,
 }: CompileNodeContext<MustacheTag>) {
   const expression = node.expression
   const value = await resolveExpression(expression, scope)
   if (value === undefined) return
+
+  if (isPromptLFile(value)) {
+    if (isInsideContentTag) {
+      addStrayText(String(value.url), node)
+      return
+    }
+
+    groupStrayText()
+
+    addContent({
+      node,
+      content: getPromptLFileContent(value),
+    })
+
+    return
+  }
 
   if (typeof value === 'object' && value !== null) {
     addStrayText(JSON.stringify(value), node)
@@ -18,4 +43,19 @@ export async function compile({
   }
 
   addStrayText(String(value), node)
+}
+
+function getPromptLFileContent(file: PromptLFile): MessageContent {
+  if (file.isImage) {
+    return {
+      type: ContentType.image,
+      image: file.url!,
+    }
+  }
+
+  return {
+    type: ContentType.file,
+    mimeType: file.mimeType,
+    file: file.url!,
+  }
 }

--- a/src/compiler/base/nodes/tags/content.ts
+++ b/src/compiler/base/nodes/tags/content.ts
@@ -67,7 +67,11 @@ export async function compile(
     return
   }
 
-  if (type === ContentType.image && stray.text.length > 0) {
+  if (type === ContentType.image) {
+    if (!stray.text.length) {
+      baseNodeError(errors.emptyContentTag, node)
+    }
+
     addContent({
       node,
       content: {
@@ -80,7 +84,11 @@ export async function compile(
     return
   }
 
-  if (type === ContentType.file && stray.text.length > 0) {
+  if (type === ContentType.file) {
+    if (!stray.text.length) {
+      baseNodeError(errors.emptyContentTag, node)
+    }
+
     const { mime: mimeType, ...rest } = attributes
     if (!mimeType) baseNodeError(errors.fileTagWithoutMimeType, node)
 

--- a/src/error/errors.ts
+++ b/src/error/errors.ts
@@ -239,6 +239,10 @@ export default {
     code: 'invalid-content-type',
     message: `Invalid content type: ${name}`,
   }),
+  emptyContentTag: {
+    code: 'empty-content-tag',
+    message: 'Content tags cannot be empty',
+  },
   invalidReferencePath: {
     code: 'invalid-reference-path',
     message: 'Reference path must be a string',

--- a/src/types/customTypes.ts
+++ b/src/types/customTypes.ts
@@ -1,0 +1,59 @@
+/**
+ * Custom file type for PromptL.
+ * It contains redundant information to make it easier to use.
+ */
+export type PromptLFile = {
+  type: string
+  mime: string
+  mimeType: string
+
+  isImage: boolean
+
+  name: string
+
+  size: number
+  bytes: number
+
+  url: string
+
+  // Used to identify it
+  __promptlType: 'file'
+}
+
+export function toPromptLFile({
+  file,
+  url,
+}: {
+  file: File
+  url: string
+}): PromptLFile {
+  const mimeType = file.type
+  const fileSize = file.size
+
+  const isImage = mimeType.startsWith('image/')
+
+  return {
+    __promptlType: 'file',
+    name: file.name,
+    url,
+    isImage,
+
+    // Redundant type
+    type: mimeType,
+    mime: mimeType,
+    mimeType: mimeType,
+
+    // Redundant size
+    size: fileSize,
+    bytes: fileSize,
+  }
+}
+
+export function isPromptLFile(value: unknown): value is PromptLFile {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    '__promptlType' in value &&
+    (value as Record<string, unknown>).__promptlType === 'file'
+  )
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,4 @@ export type ConversationMetadata = {
 
 export { type SerializedChain } from '$promptl/compiler'
 export * from './message'
+export * from './customTypes'


### PR DESCRIPTION
Added a custom opt-in `PromptLFile` type.

If a user, before rendering a prompt, adapts all of their File parameters to a `PromptLFile`, using the handy `toPromptLFile` method, PromptL will automatically insert them as content items of the message with the correct mime type and contents. There is no need for the user to specify any content tags in the prompt!

```markdown
<user>
    Take a look at this pdf:
    {{ pdf }}
    What it is about?
</user>
```

```ts
const pdf = toPromptLFile({ file, url })
const { messages } = await render({ prompt, parameters: { pdf } })
```
(Pseudo-code) OUTPUT:
```html
<message role="user">
    <content-text>
        Take a look at this pdf:
    </content-text>

    <content-file mime="application/pdf">
        https://source/file.pdf
    </content-file>

    <content-text>
        What it is about?
    </content-text>
</message>
```

Additionally, some attributes can be used in the prompt too:
```markdown
Look at this file: {{ file }}

It should be of type {{ file.type }}, be {{ file.size }}B and hosted at {{ file.url }}
```

closes: https://github.com/latitude-dev/latitude-llm/issues/959