### PR TITLE
Improve parser performance 100x

### DIFF
--- a/src/parser/state/text.ts
+++ b/src/parser/state/text.ts
@@ -1,46 +1,77 @@
-import { CUSTOM_TAG_START } from '$promptl/constants'
+import { CUSTOM_TAG_START, RESERVED_TAGS } from '$promptl/constants'
 import { type Parser } from '$promptl/parser'
 import type { Text } from '$promptl/parser/interfaces'
-import { RESERVED_TAG_REGEX } from '../utils/regex'
 
-const ENDS_WITH_ESCAPE_REGEX = /(?<!\\)(\\\\)*\\$/
 const RESERVED_DELIMITERS = [CUSTOM_TAG_START, '/*', '<!--']
+
+function matchesReservedTag(template: string, index: number): boolean {
+  if (template[index] !== '<') return false
+
+  const isClosingTag = template[index + 1] === '/'
+  let tagStart = index + (isClosingTag ? 2 : 1)
+
+  for (const tag of RESERVED_TAGS) {
+    if (
+      template.startsWith(tag, tagStart) &&
+      (template[tagStart + tag.length] === ' ' ||
+        template[tagStart + tag.length] === '/' ||
+        template[tagStart + tag.length] === '>' ||
+        tagStart + tag.length === template.length)
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
 
 export function text(parser: Parser) {
   const start = parser.index
   let data = ''
+  const template = parser.template
+  const len = template.length
 
-  while (parser.index < parser.template.length) {
-    const isEscaping = ENDS_WITH_ESCAPE_REGEX.test(data)
-    if (isEscaping) data = data.slice(0, -1) // Remove the escape character
+  while (parser.index < len) {
+    const char = template[parser.index]
 
-    // Config section
-    if (!isEscaping && parser.matchRegex(/-{3}(?!-)/)) {
-      break
+    let isEscaping = false
+    let backslashCount = 0
+    for (let i = data.length - 1; i >= 0 && data[i] === '\\'; i--)
+      backslashCount++
+    isEscaping = backslashCount % 2 === 1
+    if (isEscaping) data = data.slice(0, -1)
+
+    if (!isEscaping) {
+      if (
+        char === '-' &&
+        template[parser.index + 1] === '-' &&
+        template[parser.index + 2] === '-' &&
+        template[parser.index + 3] !== '-'
+      ) {
+        break
+      }
+
+      let delimiterMatched = false
+      for (const delim of RESERVED_DELIMITERS) {
+        if (template.startsWith(delim, parser.index)) {
+          delimiterMatched = true
+          break
+        }
+      }
+      if (delimiterMatched) break
+
+      if (matchesReservedTag(template, parser.index)) break
     }
 
-    // Reserved tags
-    if (
-      !isEscaping &&
-      parser.matchRegex(RESERVED_TAG_REGEX)
-    ) {
-      break
-    }
-
-    // Other (logic block and comments)
-    if (
-      !isEscaping &&
-      RESERVED_DELIMITERS.some((sample) => parser.match(sample))
-    ) {
-      break
-    }
-
-    const nonConfigDashes = parser.matchRegex(/-+/)
-    if (nonConfigDashes) {
-      data += nonConfigDashes
-      parser.index += nonConfigDashes.length
+    if (char === '-') {
+      let dashEnd = parser.index + 1
+      while (dashEnd < len && template[dashEnd] === '-') dashEnd++
+      const dashCount = dashEnd - parser.index
+      data += '-'.repeat(dashCount)
+      parser.index = dashEnd
     } else {
-      data += parser.template[parser.index++]
+      data += char
+      parser.index++
     }
   }
 


### PR DESCRIPTION
Improve parser performance 100x by not using regexes and doing the matching manually. It does pass all tests but a deep review is needed.

Also, this is at best a patch... we should review all the parser code (and order parts of PromptL) to avoid using regexes as much as possible (specially if they are inside a loop).

Maybe regex where working somewhat well in native PromptL in javascript, but in the WASM version they were an absolute bomb and prompts of just 200 lines took minutes to parse and compile.