### PR TITLE
feat: expose parser API

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -54,6 +54,7 @@ export default [
       'yaml',
       'crypto',
       'zod',
+      'fast-sha256',
     ],
   },
   {

--- a/src/compiler/base/nodes/tags/ref.ts
+++ b/src/compiler/base/nodes/tags/ref.ts
@@ -1,6 +1,6 @@
 import Scope from '$promptl/compiler/scope'
 import errors from '$promptl/error/errors'
-import parse from '$promptl/parser'
+import { parse } from '$promptl/parser'
 import { Fragment, ReferenceTag } from '$promptl/parser/interfaces'
 
 import { CompileNodeContext, TemplateNodeWithStatus } from '../../types'

--- a/src/compiler/chain.ts
+++ b/src/compiler/chain.ts
@@ -3,7 +3,7 @@ import {
   SerializedProps,
 } from '$promptl/compiler/deserializeChain'
 import { CHAIN_STEP_ISOLATED_ATTR } from '$promptl/constants'
-import parse from '$promptl/parser'
+import { parse } from '$promptl/parser'
 import { Fragment } from '$promptl/parser/interfaces'
 import {
   AdapterMessageType,
@@ -41,15 +41,14 @@ type BuildStepResponseContent = {
 export class Chain<M extends AdapterMessageType = Message> {
   public rawText: string
 
-  private compileOptions: CompileOptions
-  private ast: Fragment
-  private scope: Scope
-  private didStart: boolean = false
   private _completed: boolean = false
-
   private adapter: ProviderAdapter<M>
-  private globalMessages: Message[] = []
+  private ast: Fragment
+  private compileOptions: CompileOptions
+  private didStart: boolean = false
   private globalConfig: Config | undefined
+  private globalMessages: Message[] = []
+  private scope: Scope
   private wasLastStepIsolated: boolean = false
 
   static deserialize(args: SerializedProps) {
@@ -67,24 +66,21 @@ export class Chain<M extends AdapterMessageType = Message> {
     parameters?: Record<string, unknown>
     adapter?: ProviderAdapter<M>
     serialized?: {
-      ast: Fragment
-      scope: Scope
-      didStart: boolean
-      completed: boolean
-      globalConfig: Config | undefined
-      globalMessages: Message[]
+      ast?: Fragment
+      scope?: Scope
+      didStart?: boolean
+      completed?: boolean
+      globalConfig?: Config
+      globalMessages?: Message[]
     }
   } & CompileOptions) {
     this.rawText = prompt
-
-    // Init from a serialized chain
     this.ast = serialized?.ast ?? parse(prompt)
     this.scope = serialized?.scope ?? new Scope(parameters)
     this.didStart = serialized?.didStart ?? false
     this._completed = serialized?.completed ?? false
     this.globalConfig = serialized?.globalConfig
     this.globalMessages = serialized?.globalMessages ?? []
-
     this.adapter = adapter
     this.compileOptions = compileOptions
 

--- a/src/compiler/index.ts
+++ b/src/compiler/index.ts
@@ -10,6 +10,7 @@ import { z } from 'zod'
 import { Chain } from './chain'
 import { Scan } from './scan'
 import type { CompileOptions, Document, ReferencePromptFn } from './types'
+import { Fragment } from '$promptl/parser/interfaces'
 
 export async function render<M extends AdapterMessageType = Message>({
   prompt,
@@ -39,6 +40,7 @@ export function createChain({
 
 export function scan({
   prompt,
+  serialized,
   fullPath,
   referenceFn,
   withParameters,
@@ -46,6 +48,7 @@ export function scan({
   requireConfig,
 }: {
   prompt: string
+  serialized?: Fragment
   fullPath?: string
   referenceFn?: ReferencePromptFn
   withParameters?: string[]
@@ -54,6 +57,7 @@ export function scan({
 }): Promise<ConversationMetadata> {
   return new Scan({
     document: { path: fullPath ?? '', content: prompt },
+    serialized,
     referenceFn,
     withParameters,
     configSchema,

--- a/src/compiler/scan.ts
+++ b/src/compiler/scan.ts
@@ -8,7 +8,7 @@ import {
 } from '$promptl/constants'
 import CompileError, { error } from '$promptl/error/error'
 import errors from '$promptl/error/errors'
-import parse from '$promptl/parser/index'
+import { parse } from '$promptl/parser/index'
 import type {
   Attribute,
   BaseNode,
@@ -70,6 +70,7 @@ export class Scan {
   private references: { [from: string]: string[] } = {}
   private referencedHashes: string[] = []
   private referenceDepth: number = 0
+  private serialized?: Fragment
 
   constructor({
     document,
@@ -77,13 +78,16 @@ export class Scan {
     withParameters,
     configSchema,
     requireConfig,
+    serialized,
   }: {
     document: Document
     referenceFn?: ReferencePromptFn
     withParameters?: string[]
     configSchema?: z.ZodType
     requireConfig?: boolean
+    serialized?: Fragment
   }) {
+    this.serialized = serialized
     this.rawText = document.content
     this.referenceFn = referenceFn
     this.fullPath = document.path
@@ -107,7 +111,7 @@ export class Scan {
     let fragment: Fragment
 
     try {
-      fragment = parse(this.rawText)
+      fragment = this.serialized ?? parse(this.rawText)
     } catch (e) {
       const parseError = e as CompileError
       if (parseError instanceof CompileError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './types'
 export * from './compiler'
+export * from './parser'
 export * from './providers'
 
 export { default as CompileError } from './error/error'

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -7,7 +7,7 @@ import type { BaseNode, Fragment } from './interfaces'
 import fragment from './state/fragment'
 import fullCharCodeAt from './utils/full_char_code_at'
 
-export default function parse(template: string) {
+export function parse(template: string) {
   return new Parser(template).parse()
 }
 

--- a/src/parser/parser.test.ts
+++ b/src/parser/parser.test.ts
@@ -3,7 +3,7 @@ import CompileError from '$promptl/error/error'
 import { getExpectedError } from '$promptl/test/helpers'
 import { describe, expect, it } from 'vitest'
 
-import parse from '.'
+import { parse } from '.'
 import { TemplateNode } from './interfaces'
 
 describe('Fragment', async () => {

--- a/src/parser/state/mustache.test.ts
+++ b/src/parser/state/mustache.test.ts
@@ -2,7 +2,7 @@ import CompileError from '$promptl/error/error'
 import { getExpectedError } from '$promptl/test/helpers'
 import { describe, expect, it } from 'vitest'
 
-import parse from '..'
+import { parse } from '..'
 import { TemplateNode } from '../interfaces'
 
 describe('Mustache', async () => {


### PR DESCRIPTION
Parsing is an expensive computation, we now expose it to the client and accept the ast as an argument in both scan method and Chain constructor, so that clients can optimize performance.