### PR TITLE
Return AST on scan.

### DIFF
--- a/src/compiler/scan.test.ts
+++ b/src/compiler/scan.test.ts
@@ -47,6 +47,26 @@ describe('hash', async () => {
     expect(metadata1.hash).not.toBe(metadata3.hash)
   })
 
+  it('always returns ast (serialized fragments)', async () => {
+    const prompt = 'This is a prompt'
+
+    const metadata = await scan({ prompt })
+    expect(metadata.ast).toEqual({
+      start: 0,
+      end: 16,
+      type: 'Fragment',
+      children: [
+        {
+          start: 0,
+          end: 16,
+          type: 'Text',
+          raw: 'This is a prompt',
+          data: 'This is a prompt',
+        },
+      ],
+    })
+  })
+
   it('includes the content from referenced tags into account when calculating the hash', async () => {
     const parent = 'This is the parent prompt. <prompt path="child" /> The end.'
     const child1 = 'ABCDEFG'

--- a/src/compiler/scan.ts
+++ b/src/compiler/scan.ts
@@ -174,6 +174,7 @@ export class Scan {
         ...(scopeContext.onlyPredefinedVariables ?? new Set([])),
       ]),
       hash,
+      ast: fragment,
       resolvedPrompt,
       config: this.config ?? {},
       errors: this.errors,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,5 @@
 import CompileError from '$promptl/error/error'
+import { Fragment } from '$promptl/index'
 
 import { Message } from './message'
 
@@ -12,6 +13,7 @@ export type Conversation = {
 export type ConversationMetadata = {
   hash: string
   resolvedPrompt: string
+  ast: Fragment
   config: Config
   errors: CompileError[]
   parameters: Set<string> // Variables used in the prompt that have not been defined in runtime


### PR DESCRIPTION
# What?

When scanning a prompt returning the AST. using `parse` outside has the drawback that errors are not correctly handle and it breaking Latitude Playground by not showing compile errors

We have this in Latitude playground. 
```javascript
const ast = parse(prompt)
const scanParams = {
  //...other things
  serialized: ast,
}
const metadata = await scan(scanParams)
```

The problem with this is that `parse` can throw errors. This is already handle inside `scan`